### PR TITLE
Fix getDeviceFromUDN not returning result

### DIFF
--- a/lib/lib.manager.deviceManager.js
+++ b/lib/lib.manager.deviceManager.js
@@ -654,7 +654,7 @@ module.exports = class DeviceManager extends ManagerBase
         if(this.mediaRenderersVirtual.has(_id))
             return this.mediaRenderersVirtual.get(_id);
         if(this.mediaRenderers.has(_id))
-            return this.mediaRenderersVirtual.get(_id);
+            return this.mediaRenderers.get(_id);
         if(this.mediaServers.has(_id))
             return this.mediaServers.get(_id);
         return null;


### PR DESCRIPTION
Copy & paste mistake, leading to no result in case there is no virtual renderer, but a "real" one.