### PR TITLE
Favourites are not in correct order if user has items and containers bookmarked

### DIFF
--- a/lib/lib.mediaDataConverter.js
+++ b/lib/lib.mediaDataConverter.js
@@ -22,7 +22,7 @@ module.exports = class Raumkernel extends BaseManager
         return new Promise(function(_resolve, _reject){
         
             // direct conversion to json
-            ParseString(_xmlString, function (_err, _result) {
+            ParseString(_xmlString, {explicitChildren: true, preserveChildrenOrder: true}, function (_err, _result) {
                 if(!_err && _result)
                 {
                     try
@@ -50,37 +50,25 @@ module.exports = class Raumkernel extends BaseManager
                         // If we will get into a performance problem we should consider to change this code to parse directly into a nice 
                         // json format without the step xml to xml-json  to nice-json
 
-                        // there may be 2 types of containers that are returned. "items"" and "containers" and both may may be in the same result
-                        // so we have to 'loop' over the 2 types beginning with the containers
-                        for(var type=1; type<=2; type++)
+                        if(_result["DIDL-Lite"]["$$"])
                         {
-
-                            containerId = "";
-                            if(type === 1 && _result["DIDL-Lite"].container) 
-                                containerId = "container";   
-                            if(type === 2 && _result["DIDL-Lite"].item) 
-                                containerId = "item";                                                         
-                        
-                            if(containerId)
+                            var containerArray = _result["DIDL-Lite"]["$$"];
+                            for (var item of containerArray)
                             {
-                                var containerArray = _result["DIDL-Lite"][containerId];
-                                for (var item of containerArray) 
+                                try
                                 {
-                                    try
-                                    {
-                                        jsonMediaList.push(self.convertContainer(item));
-                                    }
-                                    catch(_exception)
-                                    {
-                                        // to keep the correct size of the array we put a dummy media info into the lists
-                                        jsonMediaList.push({ "title": "UNKNOWN" });
-                                        self.logError("Error converting media item: " + JSON.stringify(item), _exception);
-                                    }
+                                    jsonMediaList.push(self.convertContainer(item));
+                                }
+                                catch(_exception)
+                                {
+                                    // to keep the correct size of the array we put a dummy media info into the lists
+                                    jsonMediaList.push({ "title": "UNKNOWN" });
+                                    self.logError("Error converting media item: " + JSON.stringify(item), _exception);
                                 }
                             }
                         }
-                            
-                        
+
+
                         _resolve(jsonMediaList);
                         
                     }


### PR DESCRIPTION
This is a replacement PR of old PR https://github.com/ChriD/node-raumkernel/pull/48 


Hello,

I found an issue with Favourites: If a user has bookmarked a mix of items and containers, the sorting of the favourites returned by raumkernel is not correct. This can e.g. happen if a user has bookmarked podcasts and radio stations.

The behaviour is related to this issue within xml2js: Leonidas-from-XIV/node-xml2js#31

I tried to create a fix, but I don't have many test scenarios at hand so please merge with care only and please review before merging :)

What do you think about the approach - can there be any side effects? Are there other places in code where a similar issue could appear?

I don't have a large media library to test, so I don't know if there could be any performance side effects of the new configuration to xml2js. (Most likely not)

Best,
Uli