### PR TITLE
Fix: Podcast Album Art is not shown for Podcasts bookmarked from TuneIn

### DIFF
--- a/lib/lib.mediaDataConverter.js
+++ b/lib/lib.mediaDataConverter.js
@@ -341,7 +341,11 @@ module.exports = class Raumkernel extends BaseManager
 
      copyTrackContainerData(_newObject, _mediaContainer)
      {
-         this.copyContainerData(_newObject, _mediaContainer);        
+         this.copyContainerData(_newObject, _mediaContainer);
+
+         // if there is an "album art uri" then use it
+         if(_mediaContainer["upnp:albumArtURI"] && _mediaContainer["upnp:albumArtURI"][0])
+             _newObject["albumArtURI"] = _mediaContainer["upnp:albumArtURI"][0]._;
      }
 
 


### PR DESCRIPTION
I encountered an issue with Album Art if a trackContainer contains Album Art.

Steps to reproduce:
- Bookmark a Podcast from TuneIn to the Teufel Favourites.
- Load Favourites using node-raumkernel
- Raumkernel will not populate the albumArtUri field even though it is present in the XML response.